### PR TITLE
Add YouTube support via YoutubeExplode

### DIFF
--- a/DapolUltimate_MusicPlayer/App.config
+++ b/DapolUltimate_MusicPlayer/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <configSections>
     <section name="oracle.manageddataaccess.client" type="OracleInternal.Common.ODPMSectionHandler, Oracle.ManagedDataAccess, Version=4.122.23.1, Culture=neutral, PublicKeyToken=89b483f429c47342" />
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
       <section name="DapolUltimate_MusicPlayer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
   </configSections>
@@ -36,6 +36,18 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.1" newVersion="9.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.1" newVersion="9.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.5" newVersion="9.0.0.5" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -130,6 +130,9 @@
     <Reference Include="TagLibSharp, Version=2.3.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
       <HintPath>..\packages\TagLibSharp.2.3.0\lib\net462\TagLibSharp.dll</HintPath>
     </Reference>
+    <Reference Include="YoutubeExplode">
+      <HintPath>..\packages\YoutubeExplode.6.5.4\lib\netstandard2.0\YoutubeExplode.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -140,6 +143,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="SoundCloudService.cs" />
+    <Compile Include="YouTubeService.cs" />
     <Page Include="BaseStyles.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -37,8 +37,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.5\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.3240.44, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.WebView2.1.0.3240.44\lib\net462\Microsoft.Web.WebView2.Core.dll</HintPath>
@@ -90,6 +90,9 @@
     <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Pipelines, Version=9.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.9.0.1\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
     <Reference Include="System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.0\lib\net462\System.Memory.dll</HintPath>
     </Reference>
@@ -106,11 +109,11 @@
     <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=9.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.9.0.1\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=9.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.9.0.1\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.0\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -171,6 +171,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="MainWindow\MainWindow.YouTube.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Page Include="Themes\AeroTheme.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml
@@ -263,6 +263,35 @@
                                     </Grid>
                                 </Border>
                             </TabItem>
+                            <TabItem Header="YouTube" Style="{DynamicResource TabItemStyle}">
+                                <StackPanel Margin="10">
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                        <TextBox x:Name="YouTubeSearchBox" Width="200" Margin="0,0,10,0"/>
+                                        <Button Content="Search"
+                                                Style="{DynamicResource ButtonStyle}"
+                                                Click="YouTubeSearchButton_Click"/>
+                                    </StackPanel>
+                                    <ListBox x:Name="YouTubeResultsBox"
+                                             ItemsSource="{Binding YouTubeResults}"
+                                             ItemContainerStyle="{DynamicResource ListBoxItemStyle}"
+                                             Background="Transparent"
+                                             BorderThickness="0"
+                                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="{Binding Title}" Width="200" TextTrimming="CharacterEllipsis"/>
+                                                    <Button Content="Download"
+                                                            Style="{DynamicResource ButtonStyle}"
+                                                            Tag="{Binding}"
+                                                            Margin="10,0,0,0"
+                                                            Click="DownloadYouTubeResult_Click"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </StackPanel>
+                            </TabItem>
                         </TabControl>
                     </Grid>
 

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.YouTube.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.YouTube.cs
@@ -1,0 +1,61 @@
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using YoutubeExplode.Videos;
+
+namespace DapolUltimate_MusicPlayer {
+    public partial class MainWindow {
+        private readonly YouTubeService youTubeService = new YouTubeService();
+        private List<Video> youtubeResults = new List<Video>();
+
+        public List<Video> YouTubeResults {
+            get => youtubeResults;
+            set {
+                youtubeResults = value;
+                OnPropertyChanged(nameof(YouTubeResults));
+            }
+        }
+
+        private async void YouTubeSearchButton_Click(object sender, RoutedEventArgs e) {
+            var query = YouTubeSearchBox.Text.Trim();
+            if (string.IsNullOrEmpty(query)) return;
+
+            StatusText.Text = "Searching YouTube...";
+            try {
+                var results = await youTubeService.SearchVideosAsync(query);
+                YouTubeResults = results;
+                StatusText.Text = $"Found {results.Count} videos";
+            }
+            catch (Exception ex) {
+                MessageBox.Show($"Error searching YouTube: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                StatusText.Text = "Search failed";
+            }
+        }
+
+        private async void DownloadYouTubeResult_Click(object sender, RoutedEventArgs e) {
+            if (sender is Button button && button.Tag is Video video) {
+                var dialog = new SaveFileDialog {
+                    Filter = "MP3 files (*.mp3)|*.mp3|All files (*.*)|*.*",
+                    FileName = video.Title + ".mp3"
+                };
+
+                if (dialog.ShowDialog() == true) {
+                    StatusText.Text = "Downloading...";
+                    var url = $"https://www.youtube.com/watch?v={video.Id}";
+                    var path = await youTubeService.DownloadAudioAsync(url, dialog.FileName);
+                    if (!string.IsNullOrEmpty(path)) {
+                        playlistPaths.Add(path);
+                        OnPropertyChanged(nameof(PlaylistDisplayNames));
+                        StatusText.Text = $"Downloaded: {video.Title}";
+                    }
+                    else {
+                        StatusText.Text = "Download failed";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/YouTubeService.cs
+++ b/DapolUltimate_MusicPlayer/YouTubeService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using YoutubeExplode;
+using YoutubeExplode.Videos;
+using YoutubeExplode.Videos.Streams;
+
+namespace DapolUltimate_MusicPlayer {
+    public class YouTubeService {
+        private readonly YoutubeClient _client;
+
+        public YouTubeService() {
+            _client = new YoutubeClient();
+        }
+
+        public async Task<List<Video>> SearchVideosAsync(string query, int limit = 20) {
+            var result = await _client.Search.GetVideosAsync(query).CollectAsync(limit);
+            return result.ToList();
+        }
+
+        public async Task<string> DownloadAudioAsync(string videoUrl, string savePath) {
+            try {
+                var videoId = VideoId.Parse(videoUrl);
+                var manifest = await _client.Videos.Streams.GetManifestAsync(videoId);
+                var streamInfo = manifest.GetAudioOnlyStreams().GetWithHighestBitrate();
+
+                Directory.CreateDirectory(Path.GetDirectoryName(savePath));
+                await _client.Videos.Streams.DownloadAsync(streamInfo, savePath);
+
+                return savePath;
+            }
+            catch (Exception ex) {
+                Console.WriteLine($"Error downloading video: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/YouTubeService.cs
+++ b/DapolUltimate_MusicPlayer/YouTubeService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using YoutubeExplode;
+using YoutubeExplode.Search;
 using YoutubeExplode.Videos;
 using YoutubeExplode.Videos.Streams;
 
@@ -15,10 +16,26 @@ namespace DapolUltimate_MusicPlayer {
             _client = new YoutubeClient();
         }
 
-        public async Task<List<Video>> SearchVideosAsync(string query, int limit = 20) {
-            var result = await _client.Search.GetVideosAsync(query).CollectAsync(limit);
-            return result.ToList();
+        public async Task<List<VideoSearchResult>> SearchVideosAsync(string query, int limit = 20) {
+            var results = new List<VideoSearchResult>();
+            var asyncEnum = _client.Search.GetVideosAsync(query).GetAsyncEnumerator();
+
+            try {
+                while (await asyncEnum.MoveNextAsync()) {
+                    results.Add(asyncEnum.Current);
+                    if (results.Count >= limit)
+                        break;
+                }
+            }
+            finally {
+                await asyncEnum.DisposeAsync();
+            }
+
+            return results;
         }
+
+
+
 
         public async Task<string> DownloadAudioAsync(string videoUrl, string savePath) {
             try {

--- a/DapolUltimate_MusicPlayer/packages.config
+++ b/DapolUltimate_MusicPlayer/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
   <package id="Microsoft.Web.WebView2" version="1.0.3240.44" targetFramework="net472" />
@@ -25,4 +25,5 @@
   <package id="System.Threading.Tasks.Extensions" version="4.6.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="TagLibSharp" version="2.3.0" targetFramework="net472" />
+  <package id="YoutubeExplode" version="6.5.4" targetFramework="net472" />
 </packages>

--- a/DapolUltimate_MusicPlayer/packages.config
+++ b/DapolUltimate_MusicPlayer/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.5" targetFramework="net472" />
   <package id="Microsoft.Web.WebView2" version="1.0.3240.44" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net472" />
   <package id="NAudio" version="2.2.1" targetFramework="net472" />
@@ -15,13 +15,14 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.2" targetFramework="net472" />
   <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="9.0.1" targetFramework="net472" />
   <package id="System.Memory" version="4.6.0" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
-  <package id="System.Text.Json" version="8.0.5" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="9.0.1" targetFramework="net472" />
+  <package id="System.Text.Json" version="9.0.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="TagLibSharp" version="2.3.0" targetFramework="net472" />

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # DapolUltimate_MusicPlayer
+
+This WPF music player provides simple playback features and customizable themes.
+
+## Features
+- Local audio file playback using NAudio
+- SoundCloud track search and download
+- **New:** basic YouTube audio download support via [YoutubeExplode](https://github.com/Tyrrrz/YoutubeExplode) 6.5.4
+
+Use `YouTubeService` to search for videos and download audio streams.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This WPF music player provides simple playback features and customizable themes.
 ## Features
 - Local audio file playback using NAudio
 - SoundCloud track search and download
-- **New:** basic YouTube audio download support via [YoutubeExplode](https://github.com/Tyrrrz/YoutubeExplode) 6.5.4
+- **New:** integrated YouTube search and download using [YoutubeExplode](https://github.com/Tyrrrz/YoutubeExplode) 6.5.4
 
-Use `YouTubeService` to search for videos and download audio streams.
+Use the YouTube tab to find videos and download their audio directly into your playlist.


### PR DESCRIPTION
## Summary
- add a `YouTubeService` with async search and download methods
- reference YoutubeExplode 6.5.4
- register the new service in the project file
- document YouTube support

## Testing
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684333fddc488327ab1d8a227ad2020d