### PR TITLE
Add localization infrastructure

### DIFF
--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -189,6 +189,11 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="MainWindow\MainWindow.Localization.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="LocalizationManager.cs" />
     <Page Include="Themes\AeroTheme.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -200,6 +205,12 @@
     <Page Include="Themes\FlatTheme.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Localization\Strings.en-US.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Localization\Strings.ru-RU.xaml">
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <sys:String x:Key="WindowTitle">Dapol Ultimate Player</sys:String>
+    <sys:String x:Key="MainTitle">DAPOL ULTIMATE PLAYER</sys:String>
+    <sys:String x:Key="Subtitle">PREMIUM MUSIC EXPERIENCE</sys:String>
+    <sys:String x:Key="StatusReady">Ready</sys:String>
+    <sys:String x:Key="TracksLabel">Tracks: {0}</sys:String>
+    <sys:String x:Key="NoTrack">No track loaded</sys:String>
+    <sys:String x:Key="UnknownArtist">Unknown Artist</sys:String>
+    <sys:String x:Key="PlaylistHeader">Playlist</sys:String>
+    <sys:String x:Key="YouTubeHeader">YouTube</sys:String>
+    <sys:String x:Key="SearchButton">Search</sys:String>
+    <sys:String x:Key="AeroTheme">Aero Theme</sys:String>
+    <sys:String x:Key="FlatTheme">Flat Theme</sys:String>
+    <sys:String x:Key="DarkTheme">Dark Theme</sys:String>
+    <sys:String x:Key="LanguageEnglish">English</sys:String>
+    <sys:String x:Key="LanguageRussian">Русский</sys:String>
+</ResourceDictionary>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <sys:String x:Key="WindowTitle">Дапол Ультимейт Плеер</sys:String>
+    <sys:String x:Key="MainTitle">Дапол Ультимейт Плеер</sys:String>
+    <sys:String x:Key="Subtitle">ПРЕМИУМ МУЗЫКАЛЬНЫЙ ОПЫТ</sys:String>
+    <sys:String x:Key="StatusReady">Готово</sys:String>
+    <sys:String x:Key="TracksLabel">Треки: {0}</sys:String>
+    <sys:String x:Key="NoTrack">Трек не загружен</sys:String>
+    <sys:String x:Key="UnknownArtist">Неизвестный исполнитель</sys:String>
+    <sys:String x:Key="PlaylistHeader">Плейлист</sys:String>
+    <sys:String x:Key="YouTubeHeader">YouTube</sys:String>
+    <sys:String x:Key="SearchButton">Поиск</sys:String>
+    <sys:String x:Key="AeroTheme">Тема Aero</sys:String>
+    <sys:String x:Key="FlatTheme">Плоская тема</sys:String>
+    <sys:String x:Key="DarkTheme">Тёмная тема</sys:String>
+    <sys:String x:Key="LanguageEnglish">English</sys:String>
+    <sys:String x:Key="LanguageRussian">Русский</sys:String>
+</ResourceDictionary>

--- a/DapolUltimate_MusicPlayer/LocalizationManager.cs
+++ b/DapolUltimate_MusicPlayer/LocalizationManager.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using System.Windows;
+
+namespace DapolUltimate_MusicPlayer {
+    internal static class LocalizationManager {
+        public static void ApplyLanguage(string cultureName) {
+            try {
+                var dict = new ResourceDictionary();
+                var uri = new Uri($"pack://application:,,,/DapolUltimate_MusicPlayer;component/Localization/Strings.{cultureName}.xaml");
+                dict.Source = uri;
+
+                // remove previous localization dictionaries
+                for (int i = 0; i < Application.Current.Resources.MergedDictionaries.Count; i++) {
+                    var md = Application.Current.Resources.MergedDictionaries[i];
+                    if (md.Source != null && md.Source.OriginalString.Contains("Localization/Strings.")) {
+                        Application.Current.Resources.MergedDictionaries.Remove(md);
+                        i--;
+                    }
+                }
+                Application.Current.Resources.MergedDictionaries.Add(dict);
+
+                Properties.Settings.Default.SelectedLanguage = cultureName;
+                Properties.Settings.Default.Save();
+
+                CultureInfo.CurrentUICulture = new CultureInfo(cultureName);
+            }
+            catch {
+                // ignore errors
+            }
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="DapolUltimate_MusicPlayer.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Dapol Ultimate Player" Height="650" Width="900"
+        Title="{DynamicResource WindowTitle}" Height="650" Width="900"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
         AllowsTransparency="True"
@@ -60,7 +60,7 @@
                                BorderBrush="#80FFFFFF"
                                BorderThickness="0,1,0,0">
                         <StatusBarItem>
-                            <TextBlock x:Name="StatusText" Text="Ready" Foreground="White"/>
+                            <TextBlock x:Name="StatusText" Text="{DynamicResource StatusReady}" Foreground="White"/>
                         </StatusBarItem>
                         <StatusBarItem HorizontalAlignment="Right">
                             <TextBlock Text="{Binding Items.Count, ElementName=PlaylistBox, StringFormat=Tracks: \{0\}}" 
@@ -69,7 +69,7 @@
                     </StatusBar>
 
                     <StackPanel Grid.Row="0" Margin="0,0,0,20">
-                        <TextBlock Text="DAPOL ULTIMATE PLAYER"
+                        <TextBlock Text="{DynamicResource MainTitle}"
                                    FontSize="28"
                                    FontWeight="Bold"
                                    FontFamily="Segoe UI Light"
@@ -80,7 +80,7 @@
                             </TextBlock.Effect>
                         </TextBlock>
 
-                        <TextBlock Text="PREMIUM MUSIC EXPERIENCE"
+                        <TextBlock Text="{DynamicResource Subtitle}"
                                    FontSize="14"
                                    FontWeight="Bold"
                                    FontFamily="Segoe UI"
@@ -127,7 +127,7 @@
 
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="15,0,15,0">
                                         <TextBlock x:Name="TrackTitle"
-                                                   Text="No track loaded"
+                                                   Text="{DynamicResource NoTrack}"
                                                    FontSize="22"
                                                    FontWeight="Bold"
                                                    FontFamily="Segoe UI"
@@ -139,7 +139,7 @@
                                         </TextBlock>
 
                                         <TextBlock x:Name="TrackArtist"
-                                                   Text="Unknown Artist"
+                                                   Text="{DynamicResource UnknownArtist}"
                                                    FontSize="16"
                                                    FontFamily="Segoe UI"
                                                    Foreground="{DynamicResource TrackArtistForeground}"
@@ -209,7 +209,7 @@
                         </StackPanel>
 
                         <TabControl Grid.Column="1" Style="{DynamicResource TabControlStyle}">
-                            <TabItem Header="Playlist" Style="{DynamicResource TabItemStyle}">
+                            <TabItem Header="{DynamicResource PlaylistHeader}" Style="{DynamicResource TabItemStyle}">
                                 <Border CornerRadius="10" Background="{DynamicResource DarkGlass}"
                                         BorderBrush="#80FFFFFF"
                                         BorderThickness="1">
@@ -275,11 +275,11 @@
                                     </Grid>
                                 </Border>
                             </TabItem>
-                            <TabItem Header="YouTube" Style="{DynamicResource TabItemStyle}">
+                            <TabItem Header="{DynamicResource YouTubeHeader}" Style="{DynamicResource TabItemStyle}">
                                 <StackPanel Margin="10">
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                                         <TextBox x:Name="YouTubeSearchBox" Width="175" Margin="0,0,10,0" Height="36"/>
-                                        <Button Content="Search"
+                                        <Button Content="{DynamicResource SearchButton}"
                                                 Style="{DynamicResource ButtonStyle}"
                                                 Click="YouTubeSearchButton_Click"/>
                                     </StackPanel>
@@ -323,9 +323,15 @@
                     </Grid>
 
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,10">
-                        <Button Content="Aero Theme" Style="{DynamicResource ButtonStyle}" Click="AeroTheme_Click"/>
-                        <Button Content="Flat Theme" Style="{DynamicResource ButtonStyle}" Click="FlatTheme_Click"/>
-                        <Button Content="Dark Theme" Style="{DynamicResource ButtonStyle}" Click="DarkTheme_Click"/>
+                        <Button Content="{DynamicResource AeroTheme}" Style="{DynamicResource ButtonStyle}" Click="AeroTheme_Click"/>
+                        <Button Content="{DynamicResource FlatTheme}" Style="{DynamicResource ButtonStyle}" Click="FlatTheme_Click"/>
+                        <Button Content="{DynamicResource DarkTheme}" Style="{DynamicResource ButtonStyle}" Click="DarkTheme_Click"/>
+                        <ComboBox x:Name="LanguageSelector" Width="100" Margin="10,0,0,0"
+                                  SelectionChanged="LanguageSelector_SelectionChanged"
+                                  Style="{DynamicResource ComboBoxStyle}">
+                            <ComboBoxItem Content="{DynamicResource LanguageEnglish}"/>
+                            <ComboBoxItem Content="{DynamicResource LanguageRussian}"/>
+                        </ComboBox>
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
@@ -55,10 +55,13 @@ namespace DapolUltimate_MusicPlayer {
 
             if (!string.IsNullOrEmpty(Properties.Settings.Default.SelectedTheme)) {
                 ApplyTheme(Properties.Settings.Default.SelectedTheme);
-            }
-            else {
+            } else {
                 ApplyTheme("Aero");
             }
+
+            var lang = Properties.Settings.Default.SelectedLanguage;
+            if (string.IsNullOrEmpty(lang)) lang = "en-US";
+            LocalizationManager.ApplyLanguage(lang);
 
             InitializeTimer();
             this.PreviewKeyDown += MainWindow_PreviewKeyDown;
@@ -80,6 +83,7 @@ namespace DapolUltimate_MusicPlayer {
                 playlistIds = tracks.Select(t => t.Id).ToList();
                 OnPropertyChanged(nameof(PlaylistDisplayNames));
                 PlaylistSelector.SelectedIndex = 0;
+                LanguageSelector.SelectedIndex = lang == "ru-RU" ? 1 : 0;
             }
             catch (Exception ex) {
                 LogError(ex);

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Localization.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Localization.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DapolUltimate_MusicPlayer {
+    public partial class MainWindow {
+        private void LanguageSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (LanguageSelector.SelectedIndex == 0) {
+                LocalizationManager.ApplyLanguage("en-US");
+            } else if (LanguageSelector.SelectedIndex == 1) {
+                LocalizationManager.ApplyLanguage("ru-RU");
+            }
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/OracleDbService.cs
+++ b/DapolUltimate_MusicPlayer/OracleDbService.cs
@@ -129,7 +129,8 @@ END;";
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
                     cmd.CommandText = @"INSERT INTO PLAYLISTS (ID, NAME) VALUES (PLAYLISTS_SEQ.NEXTVAL, :name) RETURNING ID INTO :id";
-                    cmd.Parameters.Add(new OracleParameter("name", name));
+                    var nameParam = new OracleParameter("name", OracleDbType.NVarchar2) { Value = name };
+                    cmd.Parameters.Add(nameParam);
                     var idParam = new OracleParameter("id", OracleDbType.Int32, System.Data.ParameterDirection.Output);
                     cmd.Parameters.Add(idParam);
                     cmd.ExecuteNonQuery();
@@ -178,8 +179,10 @@ END;";
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
                     cmd.CommandText = @"INSERT INTO TRACKS (ID, TITLE, PATH, IS_YOUTUBE, CREATED_AT) VALUES (TRACKS_SEQ.NEXTVAL, :title, :path, :isYT, :created) RETURNING ID INTO :id";
-                    cmd.Parameters.Add(new OracleParameter("title", track.Title));
-                    cmd.Parameters.Add(new OracleParameter("path", track.Path));
+                    var titleParam = new OracleParameter("title", OracleDbType.NVarchar2) { Value = track.Title };
+                    cmd.Parameters.Add(titleParam);
+                    var pathParam = new OracleParameter("path", OracleDbType.NVarchar2) { Value = track.Path };
+                    cmd.Parameters.Add(pathParam);
                     cmd.Parameters.Add(new OracleParameter("isYT", track.IsYouTube ? 1 : 0));
                     cmd.Parameters.Add(new OracleParameter("created", track.CreatedAt));
                     var idParam = new OracleParameter("id", OracleDbType.Int32, System.Data.ParameterDirection.Output);

--- a/DapolUltimate_MusicPlayer/Properties/Settings.Designer.cs
+++ b/DapolUltimate_MusicPlayer/Properties/Settings.Designer.cs
@@ -34,5 +34,17 @@ namespace DapolUltimate_MusicPlayer.Properties {
                 this["SelectedTheme"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SelectedLanguage {
+            get {
+                return ((string)(this["SelectedLanguage"]));
+            }
+            set {
+                this["SelectedLanguage"] = value;
+            }
+        }
     }
 }

--- a/DapolUltimate_MusicPlayer/Properties/Settings.settings
+++ b/DapolUltimate_MusicPlayer/Properties/Settings.settings
@@ -5,5 +5,8 @@
     <Setting Name="SelectedTheme" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="SelectedLanguage" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- add resource dictionaries for English and Russian translations
- track selected language in user settings
- create `LocalizationManager` helper and `MainWindow` logic for language switching
- include language picker in the UI

## Testing
- `dotnet build DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441f47e6e083279ae3b3950b649fa9