### PR TITLE
Add user favorites and playback stats

### DIFF
--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -194,6 +194,20 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="MainWindow\MainWindow.Favorites.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Page Include="LoginWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="LoginWindow.xaml.cs">
+      <DependentUpon>LoginWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="UserInfo.cs" />
+    <Compile Include="TrackStatInfo.cs" />
     <Compile Include="LocalizationManager.cs" />
     <Page Include="Themes\AeroTheme.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
+++ b/DapolUltimate_MusicPlayer/DapolUltimate_MusicPlayer.csproj
@@ -227,6 +227,9 @@
     <Page Include="Localization\Strings.ru-RU.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Localization\Strings.pl-PL.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
@@ -10,6 +10,13 @@
     <sys:String x:Key="UnknownArtist">Unknown Artist</sys:String>
     <sys:String x:Key="PlaylistHeader">Playlist</sys:String>
     <sys:String x:Key="YouTubeHeader">YouTube</sys:String>
+    <sys:String x:Key="FavoritesHeader">Favorites</sys:String>
+    <sys:String x:Key="StatsHeader">Top Played</sys:String>
+    <sys:String x:Key="LoginTitle">Login</sys:String>
+    <sys:String x:Key="UsernameLabel">Username</sys:String>
+    <sys:String x:Key="PasswordLabel">Password</sys:String>
+    <sys:String x:Key="LoginButton">Login</sys:String>
+    <sys:String x:Key="RegisterButton">Register</sys:String>
     <sys:String x:Key="SearchButton">Search</sys:String>
     <sys:String x:Key="AeroTheme">Aero Theme</sys:String>
     <sys:String x:Key="FlatTheme">Flat Theme</sys:String>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.en-US.xaml
@@ -23,4 +23,9 @@
     <sys:String x:Key="DarkTheme">Dark Theme</sys:String>
     <sys:String x:Key="LanguageEnglish">English</sys:String>
     <sys:String x:Key="LanguageRussian">Русский</sys:String>
+    <sys:String x:Key="LanguagePolish">Polish</sys:String>
+    <sys:String x:Key="UserExists">User already exists</sys:String>
+    <sys:String x:Key="PlaylistExists">Playlist already exists</sys:String>
+    <sys:String x:Key="InvalidCredentials">Invalid credentials</sys:String>
+    <sys:String x:Key="EnterCredentials">Enter username and password</sys:String>
 </ResourceDictionary>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.pl-PL.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.pl-PL.xaml
@@ -1,0 +1,31 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <sys:String x:Key="WindowTitle">Dapol Ultimate Player</sys:String>
+    <sys:String x:Key="MainTitle">DAPOL ULTIMATE PLAYER</sys:String>
+    <sys:String x:Key="Subtitle">PREMIUMOWE DOŚWIADCZENIE MUZYCZNE</sys:String>
+    <sys:String x:Key="StatusReady">Gotowe</sys:String>
+    <sys:String x:Key="TracksLabel">Utwory: {0}</sys:String>
+    <sys:String x:Key="NoTrack">Brak załadowanego utworu</sys:String>
+    <sys:String x:Key="UnknownArtist">Nieznany wykonawca</sys:String>
+    <sys:String x:Key="PlaylistHeader">Lista odtwarzania</sys:String>
+    <sys:String x:Key="YouTubeHeader">YouTube</sys:String>
+    <sys:String x:Key="FavoritesHeader">Ulubione</sys:String>
+    <sys:String x:Key="StatsHeader">Najczęściej odtwarzane</sys:String>
+    <sys:String x:Key="LoginTitle">Logowanie</sys:String>
+    <sys:String x:Key="UsernameLabel">Nazwa użytkownika</sys:String>
+    <sys:String x:Key="PasswordLabel">Hasło</sys:String>
+    <sys:String x:Key="LoginButton">Zaloguj</sys:String>
+    <sys:String x:Key="RegisterButton">Rejestracja</sys:String>
+    <sys:String x:Key="SearchButton">Szukaj</sys:String>
+    <sys:String x:Key="AeroTheme">Motyw Aero</sys:String>
+    <sys:String x:Key="FlatTheme">Motyw płaski</sys:String>
+    <sys:String x:Key="DarkTheme">Ciemny motyw</sys:String>
+    <sys:String x:Key="LanguageEnglish">Angielski</sys:String>
+    <sys:String x:Key="LanguageRussian">Русский</sys:String>
+    <sys:String x:Key="LanguagePolish">Polski</sys:String>
+    <sys:String x:Key="UserExists">Użytkownik już istnieje</sys:String>
+    <sys:String x:Key="PlaylistExists">Lista o takiej nazwie już istnieje</sys:String>
+    <sys:String x:Key="InvalidCredentials">Nieprawidłowe dane logowania</sys:String>
+    <sys:String x:Key="EnterCredentials">Wpisz nazwę użytkownika i hasło</sys:String>
+</ResourceDictionary>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
@@ -10,6 +10,13 @@
     <sys:String x:Key="UnknownArtist">Неизвестный исполнитель</sys:String>
     <sys:String x:Key="PlaylistHeader">Плейлист</sys:String>
     <sys:String x:Key="YouTubeHeader">YouTube</sys:String>
+    <sys:String x:Key="FavoritesHeader">Избранное</sys:String>
+    <sys:String x:Key="StatsHeader">Топ прослушиваний</sys:String>
+    <sys:String x:Key="LoginTitle">Вход</sys:String>
+    <sys:String x:Key="UsernameLabel">Логин</sys:String>
+    <sys:String x:Key="PasswordLabel">Пароль</sys:String>
+    <sys:String x:Key="LoginButton">Войти</sys:String>
+    <sys:String x:Key="RegisterButton">Регистрация</sys:String>
     <sys:String x:Key="SearchButton">Поиск</sys:String>
     <sys:String x:Key="AeroTheme">Тема Aero</sys:String>
     <sys:String x:Key="FlatTheme">Плоская тема</sys:String>

--- a/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
+++ b/DapolUltimate_MusicPlayer/Localization/Strings.ru-RU.xaml
@@ -23,4 +23,9 @@
     <sys:String x:Key="DarkTheme">Тёмная тема</sys:String>
     <sys:String x:Key="LanguageEnglish">English</sys:String>
     <sys:String x:Key="LanguageRussian">Русский</sys:String>
+    <sys:String x:Key="LanguagePolish">Polski</sys:String>
+    <sys:String x:Key="UserExists">Пользователь уже существует</sys:String>
+    <sys:String x:Key="PlaylistExists">Плейлист с таким именем уже существует</sys:String>
+    <sys:String x:Key="InvalidCredentials">Неверные данные для входа</sys:String>
+    <sys:String x:Key="EnterCredentials">Введите логин и пароль</sys:String>
 </ResourceDictionary>

--- a/DapolUltimate_MusicPlayer/LoginWindow.xaml
+++ b/DapolUltimate_MusicPlayer/LoginWindow.xaml
@@ -1,0 +1,16 @@
+<Window x:Class="DapolUltimate_MusicPlayer.LoginWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{DynamicResource LoginTitle}" Height="200" Width="300"
+        WindowStartupLocation="CenterScreen">
+    <StackPanel Margin="20">
+        <TextBlock Text="{DynamicResource UsernameLabel}" Margin="0,0,0,5"/>
+        <TextBox x:Name="UsernameBox" Margin="0,0,0,10"/>
+        <TextBlock Text="{DynamicResource PasswordLabel}" Margin="0,0,0,5"/>
+        <PasswordBox x:Name="PasswordBox" Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="{DynamicResource LoginButton}" Click="Login_Click" Margin="0,0,5,0"/>
+            <Button Content="{DynamicResource RegisterButton}" Click="Register_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DapolUltimate_MusicPlayer/LoginWindow.xaml.cs
+++ b/DapolUltimate_MusicPlayer/LoginWindow.xaml.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Windows;
+
+namespace DapolUltimate_MusicPlayer {
+    public partial class LoginWindow : Window {
+        private readonly OracleDbService dbService = new OracleDbService();
+        public int? UserId { get; private set; }
+
+        public LoginWindow() {
+            InitializeComponent();
+        }
+
+        private void Login_Click(object sender, RoutedEventArgs e) {
+            var user = dbService.GetUserByUsername(UsernameBox.Text.Trim());
+            var hash = ComputeHash(PasswordBox.Password);
+            if (user != null && user.PasswordHash == hash) {
+                UserId = user.Id;
+                DialogResult = true;
+            } else {
+                MessageBox.Show("Invalid credentials");
+            }
+        }
+
+        private void Register_Click(object sender, RoutedEventArgs e) {
+            if (string.IsNullOrWhiteSpace(UsernameBox.Text) || string.IsNullOrWhiteSpace(PasswordBox.Password)) {
+                MessageBox.Show("Enter username and password");
+                return;
+            }
+            var hash = ComputeHash(PasswordBox.Password);
+            try {
+                UserId = dbService.RegisterUser(UsernameBox.Text.Trim(), hash);
+                DialogResult = true;
+            } catch (Exception ex) {
+                MessageBox.Show($"Registration error: {ex.Message}");
+            }
+        }
+
+        private string ComputeHash(string s) {
+            using var sha = SHA256.Create();
+            var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(s));
+            return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/LoginWindow.xaml.cs
+++ b/DapolUltimate_MusicPlayer/LoginWindow.xaml.cs
@@ -19,19 +19,21 @@ namespace DapolUltimate_MusicPlayer {
                 UserId = user.Id;
                 DialogResult = true;
             } else {
-                MessageBox.Show("Invalid credentials");
+                MessageBox.Show((string)FindResource("InvalidCredentials"));
             }
         }
 
         private void Register_Click(object sender, RoutedEventArgs e) {
             if (string.IsNullOrWhiteSpace(UsernameBox.Text) || string.IsNullOrWhiteSpace(PasswordBox.Password)) {
-                MessageBox.Show("Enter username and password");
+                MessageBox.Show((string)FindResource("EnterCredentials"));
                 return;
             }
             var hash = ComputeHash(PasswordBox.Password);
             try {
                 UserId = dbService.RegisterUser(UsernameBox.Text.Trim(), hash);
                 DialogResult = true;
+            } catch (InvalidOperationException ex) when (ex.Message == "USER_EXISTS") {
+                MessageBox.Show((string)FindResource("UserExists"));
             } catch (Exception ex) {
                 MessageBox.Show($"Registration error: {ex.Message}");
             }

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml
@@ -322,6 +322,41 @@
                                     </ListBox>
                                 </StackPanel>
                             </TabItem>
+                            <TabItem Header="{DynamicResource FavoritesHeader}" Style="{DynamicResource TabItemStyle}">
+                                <Border CornerRadius="10" Background="{DynamicResource DarkGlass}" BorderBrush="#80FFFFFF" BorderThickness="1">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="5" ShadowDepth="0" Opacity="0.3" Color="#FF0078D7"/>
+                                    </Border.Effect>
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <ListBox x:Name="FavoritesBox" ItemsSource="{Binding FavoriteTracks}" ItemContainerStyle="{DynamicResource ListBoxItemStyle}" Background="Transparent" BorderThickness="0" MouseDoubleClick="FavoritesBox_MouseDoubleClick"/>
+                                        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,10,5">
+                                            <Button Content="+" Width="25" Height="25" Margin="0,0,5,0" Style="{DynamicResource RoundButtonStyle}" Click="AddFavorite_Click"/>
+                                            <Button Content="-" Width="25" Height="25" Style="{DynamicResource RoundButtonStyle}" Click="RemoveFavorite_Click"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </TabItem>
+                            <TabItem Header="{DynamicResource StatsHeader}" Style="{DynamicResource TabItemStyle}">
+                                <Border CornerRadius="10" Background="{DynamicResource DarkGlass}" BorderBrush="#80FFFFFF" BorderThickness="1">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="5" ShadowDepth="0" Opacity="0.3" Color="#FF0078D7"/>
+                                    </Border.Effect>
+                                    <ListBox x:Name="StatsBox" ItemsSource="{Binding TopTracks}" ItemContainerStyle="{DynamicResource ListBoxItemStyle}" Background="Transparent" BorderThickness="0">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="{Binding Track.Title}" Width="160" TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Text="{Binding PlayCount}" Margin="10,0,0,0"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </Border>
+                            </TabItem>
                         </TabControl>
                     </Grid>
 

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml
@@ -369,6 +369,7 @@
                                   Style="{DynamicResource ComboBoxStyle}">
                             <ComboBoxItem Content="{DynamicResource LanguageEnglish}"/>
                             <ComboBoxItem Content="{DynamicResource LanguageRussian}"/>
+                            <ComboBoxItem Content="{DynamicResource LanguagePolish}"/>
                         </ComboBox>
                     </StackPanel>
                 </Grid>

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
@@ -78,9 +78,9 @@ namespace DapolUltimate_MusicPlayer {
                     return;
                 }
 
-                playlists = dbService.LoadPlaylists();
+                playlists = dbService.LoadPlaylists(userId);
                 if (playlists.Count == 0) {
-                    var id = dbService.AddPlaylist("Default");
+                    var id = dbService.AddPlaylist("Default", userId);
                     playlists.Add(new PlaylistInfo { Id = id, Name = "Default" });
                 }
                 OnPropertyChanged(nameof(PlaylistNames));
@@ -91,7 +91,11 @@ namespace DapolUltimate_MusicPlayer {
                 playlistIds = tracks.Select(t => t.Id).ToList();
                 OnPropertyChanged(nameof(PlaylistDisplayNames));
                 PlaylistSelector.SelectedIndex = 0;
-                LanguageSelector.SelectedIndex = lang == "ru-RU" ? 1 : 0;
+                LanguageSelector.SelectedIndex = lang switch {
+                    "ru-RU" => 1,
+                    "pl-PL" => 2,
+                    _ => 0
+                };
                 LoadFavorites();
                 LoadStats();
             }

--- a/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow.xaml.cs
@@ -70,6 +70,14 @@ namespace DapolUltimate_MusicPlayer {
             try {
                 dbService.EnsureTableExists();
 
+                var login = new LoginWindow();
+                if (login.ShowDialog() == true && login.UserId.HasValue) {
+                    userId = login.UserId.Value;
+                } else {
+                    Close();
+                    return;
+                }
+
                 playlists = dbService.LoadPlaylists();
                 if (playlists.Count == 0) {
                     var id = dbService.AddPlaylist("Default");
@@ -84,6 +92,8 @@ namespace DapolUltimate_MusicPlayer {
                 OnPropertyChanged(nameof(PlaylistDisplayNames));
                 PlaylistSelector.SelectedIndex = 0;
                 LanguageSelector.SelectedIndex = lang == "ru-RU" ? 1 : 0;
+                LoadFavorites();
+                LoadStats();
             }
             catch (Exception ex) {
                 LogError(ex);

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Favorites.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Favorites.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+
+namespace DapolUltimate_MusicPlayer {
+    public partial class MainWindow {
+        private int userId;
+        private List<TrackInfo> favoriteTracks = new List<TrackInfo>();
+        private List<TrackStatInfo> topTracks = new List<TrackStatInfo>();
+
+        public List<TrackInfo> FavoriteTracks {
+            get => favoriteTracks;
+            set { favoriteTracks = value; OnPropertyChanged(nameof(FavoriteTracks)); }
+        }
+
+        public List<TrackStatInfo> TopTracks {
+            get => topTracks;
+            set { topTracks = value; OnPropertyChanged(nameof(TopTracks)); }
+        }
+
+        private void LoadFavorites() {
+            if (userId > 0)
+                FavoriteTracks = dbService.GetUserFavorites(userId);
+        }
+
+        private void LoadStats() {
+            TopTracks = dbService.GetTopPlayedTracks(10);
+        }
+
+        private void AddFavorite_Click(object sender, RoutedEventArgs e) {
+            if (userId <= 0 || currentTrackIndex < 0 || currentTrackIndex >= playlistIds.Count)
+                return;
+            dbService.AddFavorite(userId, playlistIds[currentTrackIndex]);
+            LoadFavorites();
+        }
+
+        private void RemoveFavorite_Click(object sender, RoutedEventArgs e) {
+            if (userId <= 0 || FavoritesBox.SelectedItem is not TrackInfo track)
+                return;
+            dbService.RemoveFavorite(userId, track.Id);
+            LoadFavorites();
+        }
+
+        private void FavoritesBox_MouseDoubleClick(object sender, MouseButtonEventArgs e) {
+            if (FavoritesBox.SelectedItem is TrackInfo track) {
+                int index = playlistIds.IndexOf(track.Id);
+                if (index == -1) {
+                    playlistPaths.Add(track.Path);
+                    playlistIds.Add(track.Id);
+                    index = playlistIds.Count - 1;
+                    OnPropertyChanged(nameof(PlaylistDisplayNames));
+                }
+                currentTrackIndex = index;
+                LoadAndPlayFile(track.Path);
+                PlaylistBox.SelectedIndex = currentTrackIndex;
+            }
+        }
+    }
+}

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Localization.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Localization.cs
@@ -8,6 +8,8 @@ namespace DapolUltimate_MusicPlayer {
                 LocalizationManager.ApplyLanguage("en-US");
             } else if (LanguageSelector.SelectedIndex == 1) {
                 LocalizationManager.ApplyLanguage("ru-RU");
+            } else if (LanguageSelector.SelectedIndex == 2) {
+                LocalizationManager.ApplyLanguage("pl-PL");
             }
         }
     }

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Playback.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Playback.cs
@@ -278,6 +278,10 @@ namespace DapolUltimate_MusicPlayer {
                 PlayPauseButton.Content = "⏸";
 
                 StatusText.Text = $"Now playing: {TrackTitle.Text}";
+                if (userId > 0 && currentTrackIndex >= 0 && currentTrackIndex < playlistIds.Count) {
+                    dbService.RecordPlayback(userId, playlistIds[currentTrackIndex]);
+                    LoadStats();
+                }
             }
             catch (Exception ex) {
                 MessageBox.Show($"Error loading file: {ex.Message}", "Error",

--- a/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Playlist.cs
+++ b/DapolUltimate_MusicPlayer/MainWindow/MainWindow.Playlist.cs
@@ -29,7 +29,11 @@ namespace DapolUltimate_MusicPlayer {
         private void AddPlaylist_Click(object sender, RoutedEventArgs e) {
             var name = Interaction.InputBox("Playlist name", "New Playlist", "");
             if (string.IsNullOrWhiteSpace(name)) return;
-            var id = dbService.AddPlaylist(name);
+            if (dbService.PlaylistExists(userId, name)) {
+                MessageBox.Show((string)FindResource("PlaylistExists"));
+                return;
+            }
+            var id = dbService.AddPlaylist(name, userId);
             playlists.Add(new PlaylistInfo { Id = id, Name = name });
             OnPropertyChanged(nameof(PlaylistNames));
             PlaylistSelector.SelectedIndex = playlists.Count - 1;
@@ -137,7 +141,7 @@ namespace DapolUltimate_MusicPlayer {
                     ResetPlayerState();
                 }
 
-                dbService.DeletePlaylist(id);
+                dbService.DeletePlaylist(id, userId);
                 playlists.RemoveAt(index);
                 OnPropertyChanged(nameof(PlaylistNames));
 

--- a/DapolUltimate_MusicPlayer/OracleDbService.cs
+++ b/DapolUltimate_MusicPlayer/OracleDbService.cs
@@ -18,6 +18,7 @@ namespace DapolUltimate_MusicPlayer {
                 conn.Open();
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   TRACKS
                     cmd.CommandText = @"
 BEGIN
@@ -37,6 +38,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //  SEQUENCE TRACKS_SEQ
                     cmd.CommandText = @"
 BEGIN
@@ -54,6 +56,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   PLAYLISTS
                     cmd.CommandText = @"
 BEGIN
@@ -72,6 +75,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //  SEQUENCE PLAYLISTS_SEQ
                     cmd.CommandText = @"
 BEGIN
@@ -89,6 +93,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   PLAYLIST_TRACKS
                     cmd.CommandText = @"
 BEGIN
@@ -106,6 +111,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   USERS
                     cmd.CommandText = @"
 BEGIN
@@ -124,6 +130,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //  SEQUENCE USERS_SEQ
                     cmd.CommandText = @"
 BEGIN
@@ -141,6 +148,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   FAVORITES
                     cmd.CommandText = @"
 BEGIN
@@ -160,6 +168,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //  SEQUENCE FAVORITES_SEQ
                     cmd.CommandText = @"
 BEGIN
@@ -177,6 +186,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //   PLAYBACK_STATS
                     cmd.CommandText = @"
 BEGIN
@@ -195,6 +205,7 @@ END;";
                 }
 
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     //  SEQUENCE PLAYBACK_STATS_SEQ
                     cmd.CommandText = @"
 BEGIN
@@ -218,6 +229,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "SELECT ID, NAME FROM PLAYLISTS WHERE USER_ID = :uid ORDER BY ID";
                     cmd.Parameters.Add(new OracleParameter("uid", userId));
                     using (var reader = cmd.ExecuteReader()) {
@@ -237,6 +249,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"INSERT INTO PLAYLISTS (ID, USER_ID, NAME) VALUES (PLAYLISTS_SEQ.NEXTVAL, :uid, :name) RETURNING ID INTO :id";
                     cmd.Parameters.Add(new OracleParameter("uid", userId));
                     var nameParam = new OracleParameter("name", OracleDbType.NVarchar2) { Value = name };
@@ -253,6 +266,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "UPDATE PLAYLISTS SET NAME = :name WHERE ID = :id";
                     cmd.Parameters.Add(new OracleParameter("name", OracleDbType.NVarchar2) { Value = newName });
                     cmd.Parameters.Add(new OracleParameter("id", playlistId));
@@ -266,6 +280,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"SELECT t.ID, t.TITLE, t.PATH, t.IS_YOUTUBE, t.CREATED_AT FROM TRACKS t JOIN PLAYLIST_TRACKS p ON t.ID = p.TRACK_ID WHERE p.PLAYLIST_ID = :pid ORDER BY t.ID";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     using (var reader = cmd.ExecuteReader()) {
@@ -288,6 +303,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "INSERT INTO PLAYLIST_TRACKS (PLAYLIST_ID, TRACK_ID) VALUES (:pid, :tid)";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     cmd.Parameters.Add(new OracleParameter("tid", trackId));
@@ -300,6 +316,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"INSERT INTO TRACKS (ID, TITLE, PATH, IS_YOUTUBE, CREATED_AT) VALUES (TRACKS_SEQ.NEXTVAL, :title, :path, :isYT, :created) RETURNING ID INTO :id";
                     var titleParam = new OracleParameter("title", OracleDbType.NVarchar2) { Value = track.Title };
                     cmd.Parameters.Add(titleParam);
@@ -319,12 +336,14 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "DELETE FROM PLAYLIST_TRACKS WHERE PLAYLIST_ID = :pid AND TRACK_ID = :tid";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     cmd.Parameters.Add(new OracleParameter("tid", trackId));
                     cmd.ExecuteNonQuery();
                 }
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "DELETE FROM TRACKS WHERE ID = :id";
                     cmd.Parameters.Add(new OracleParameter("id", trackId));
                     cmd.ExecuteNonQuery();
@@ -336,17 +355,20 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText =
                         "DELETE FROM TRACKS WHERE ID IN (SELECT TRACK_ID FROM PLAYLIST_TRACKS WHERE PLAYLIST_ID = :pid)";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     cmd.ExecuteNonQuery();
                 }
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "DELETE FROM PLAYLIST_TRACKS WHERE PLAYLIST_ID = :pid";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     cmd.ExecuteNonQuery();
                 }
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "DELETE FROM PLAYLISTS WHERE ID = :pid AND USER_ID = :uid";
                     cmd.Parameters.Add(new OracleParameter("pid", playlistId));
                     cmd.Parameters.Add(new OracleParameter("uid", userId));
@@ -361,6 +383,7 @@ END;";
                 if (GetUserByUsername(username) != null)
                     throw new InvalidOperationException("USER_EXISTS");
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"INSERT INTO USERS (ID, USERNAME, PASSWORD_HASH, CREATED_AT) VALUES (USERS_SEQ.NEXTVAL, :u, :p, :c) RETURNING ID INTO :id";
                     cmd.Parameters.Add(new OracleParameter("u", username));
                     cmd.Parameters.Add(new OracleParameter("p", passwordHash));
@@ -377,6 +400,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "SELECT ID, USERNAME, PASSWORD_HASH, CREATED_AT FROM USERS WHERE USERNAME = :u";
                     cmd.Parameters.Add(new OracleParameter("u", username));
                     using (var reader = cmd.ExecuteReader()) {
@@ -398,6 +422,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "SELECT 1 FROM PLAYLISTS WHERE USER_ID = :uid AND NAME = :n";
                     cmd.Parameters.Add(new OracleParameter("uid", userId));
                     cmd.Parameters.Add(new OracleParameter("n", name));
@@ -411,6 +436,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"INSERT INTO FAVORITES (ID, USER_ID, TRACK_ID, CREATED_AT) VALUES (FAVORITES_SEQ.NEXTVAL, :u, :t, :c)";
                     cmd.Parameters.Add(new OracleParameter("u", userId));
                     cmd.Parameters.Add(new OracleParameter("t", trackId));
@@ -424,6 +450,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = "DELETE FROM FAVORITES WHERE USER_ID = :u AND TRACK_ID = :t";
                     cmd.Parameters.Add(new OracleParameter("u", userId));
                     cmd.Parameters.Add(new OracleParameter("t", trackId));
@@ -437,6 +464,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"SELECT t.ID, t.TITLE, t.PATH, t.IS_YOUTUBE, t.CREATED_AT FROM TRACKS t JOIN FAVORITES f ON t.ID = f.TRACK_ID WHERE f.USER_ID = :u ORDER BY f.CREATED_AT DESC";
                     cmd.Parameters.Add(new OracleParameter("u", userId));
                     using (var reader = cmd.ExecuteReader()) {
@@ -459,6 +487,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"INSERT INTO PLAYBACK_STATS (ID, USER_ID, TRACK_ID, PLAYED_AT) VALUES (PLAYBACK_STATS_SEQ.NEXTVAL, :u, :t, :c)";
                     cmd.Parameters.Add(new OracleParameter("u", userId));
                     cmd.Parameters.Add(new OracleParameter("t", trackId));
@@ -473,6 +502,7 @@ END;";
             using (var conn = GetConnection()) {
                 conn.Open();
                 using (var cmd = conn.CreateCommand()) {
+                    cmd.BindByName = true;
                     cmd.CommandText = @"SELECT * FROM (
                         SELECT t.ID, t.TITLE, t.PATH, t.IS_YOUTUBE, t.CREATED_AT, COUNT(*) AS C
                         FROM TRACKS t JOIN PLAYBACK_STATS p ON t.ID = p.TRACK_ID

--- a/DapolUltimate_MusicPlayer/TrackStatInfo.cs
+++ b/DapolUltimate_MusicPlayer/TrackStatInfo.cs
@@ -1,0 +1,6 @@
+namespace DapolUltimate_MusicPlayer {
+    public class TrackStatInfo {
+        public TrackInfo Track { get; set; }
+        public int PlayCount { get; set; }
+    }
+}

--- a/DapolUltimate_MusicPlayer/UserInfo.cs
+++ b/DapolUltimate_MusicPlayer/UserInfo.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace DapolUltimate_MusicPlayer {
+    public class UserInfo {
+        public int Id { get; set; }
+        public string Username { get; set; }
+        public string PasswordHash { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- create login window and add new tabs for favorites and play statistics
- integrate new tables into `OracleDbService`
- implement registration, favorites, playback logging and stats
- update themes and localization strings

## Testing
- `dotnet build DapolUltimate_MusicPlayer.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ec16a3cc832786ce27db8d459937